### PR TITLE
add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '42 5 * * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.30', '5.36' ]
+        exclude:
+          - runner: windows-latest
+            perl: '5.36'
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Dist::Zilla
+      run: |
+        cpanm -v
+        cpanm --notest Dist::Zilla
+
+    - name: Install Modules
+      run: |
+        dzil authordeps --missing | cpanm --notest
+        dzil listdeps --develop --missing | cpanm --notest
+
+    - name: Show Errors on Windows
+      if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
+      run: |
+         ls -l C:/Users/
+         ls -l C:/Users/RUNNER~1/
+         cat C:/Users/runneradmin/.cpanm/work/*/build.log
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
+
+    - name: Run tests
+      env:
+        AUTHOR_TESTING: 1
+        RELEASE_TESTING: 1
+      run: |
+        dzil test
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         exclude:
           - runner: windows-latest
             perl: '5.36'
+          - runner: windows-latest
+            perl: '5.10'
 
     runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
@@ -61,5 +63,5 @@ jobs:
         AUTHOR_TESTING: 1
         RELEASE_TESTING: 1
       run: |
-        prove
+        prove -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
             perl: '5.36'
           - runner: windows-latest
             perl: '5.10'
+          - runner: macos-latest
+            perl: '5.36'
+          - runner: macos-latest
+            perl: '5.10'
 
     runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Modules
       run: |
         cpanm -v
-        cpanm --installdeps .
+        cpanm --installdeps --notest .
 
     - name: Show Errors on Windows
       if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,26 +35,31 @@ jobs:
     - name: Show Perl Version
       run: |
         perl -v
-
-    - name: Install Modules
-      run: |
         cpanm -v
+        
+    - name: Install Test::More
+      if:  ${{ startsWith( matrix.perl, '5.10') }}
+      run: |
+        cpanm --notest Test::More
+
+    - name: Install dependencies
+      run: |
         cpanm --installdeps --notest .
 
     - name: Show Errors on Windows
-      if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
+      if:  ${{ failure() && startsWith( matrix.runner, 'windows-') }}
       run: |
          ls -l C:/Users/
          ls -l C:/Users/RUNNER~1/
          cat C:/Users/runneradmin/.cpanm/work/*/build.log
 
     - name: Show Errors on Ubuntu
-      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-') }}
       run: |
          cat /home/runner/.cpanm/work/*/build.log
 
     - name: Show Errors on OSX
-      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-') }}
       run: |
          cat  /Users/runner/.cpanm/work/*/build.log
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,5 @@ jobs:
         AUTHOR_TESTING: 1
         RELEASE_TESTING: 1
       run: |
-        prove -v
+        prove -l -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '42 5 * * 0'
+    - cron: '0 3 * * 0'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '42 5 * * *'
+    - cron: '42 5 * * 0'
 
 jobs:
   test:
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest, macos-latest, windows-latest]
-        perl: [ '5.30', '5.36' ]
+        perl: [ '5.10', '5.30', '5.36' ]
         exclude:
           - runner: windows-latest
             perl: '5.36'
@@ -34,15 +34,10 @@ jobs:
       run: |
         perl -v
 
-    - name: Install Dist::Zilla
-      run: |
-        cpanm -v
-        cpanm --notest Dist::Zilla
-
     - name: Install Modules
       run: |
-        dzil authordeps --missing | cpanm --notest
-        dzil listdeps --develop --missing | cpanm --notest
+        cpanm -v
+        cpanm --installdeps .
 
     - name: Show Errors on Windows
       if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
@@ -66,5 +61,5 @@ jobs:
         AUTHOR_TESTING: 1
         RELEASE_TESTING: 1
       run: |
-        dzil test
+        prove
 


### PR DESCRIPTION
As mentioned in the Perl Weekly as well, I think it can be really valuable to enable Continuous Integration (CI) and improve testing on all the CPAN modules where the author is interested in it. Having CI configured will provide fast feedback to the author(s) and will reduce the chances of releasing a module that only works on the computer of the developer. Reducing the manual work-load for the CPAN Tester. Currently GitHub Actions is the most natural CI system for GitHub-based projects. That's why I am sending this PR.

I've enabled several versions of Perl on 3 different platforms. Except 5.36 on Windows as it does not seem to exist.



I have written several blog posts and recorded videos on the subject. You can find them here: https://perlmaven.com/os
If you need further help with the CI system, check out my posts https://perlmaven.com/ci and feel free to ask me.

If you'd like to support my efforts there are several ways to do so https://szabgab.com/support.html

